### PR TITLE
Remove order enforcing

### DIFF
--- a/momadm_benchmarks/envs/beach_domain/beach_domain.py
+++ b/momadm_benchmarks/envs/beach_domain/beach_domain.py
@@ -42,9 +42,6 @@ def env(**kwargs):
     env = raw_env(**kwargs)
     # this wrapper helps error handling for discrete action spaces
     env = wrappers.AssertOutOfBoundsWrapper(env)
-    # Provides a wide vareity of helpful user errors
-    # Strongly recommended
-    env = wrappers.OrderEnforcingWrapper(env)
     return env
 
 

--- a/momadm_benchmarks/utils/conversions.py
+++ b/momadm_benchmarks/utils/conversions.py
@@ -12,7 +12,6 @@ from pettingzoo.utils.conversions import (
     parallel_to_aec_wrapper,
 )
 from pettingzoo.utils.env import AECEnv, ParallelEnv
-from pettingzoo.utils.wrappers import OrderEnforcingWrapper
 
 from momadm_benchmarks.utils.env import MOAECEnv, MOParallelEnv
 
@@ -23,7 +22,7 @@ def mo_aec_to_parallel(aec_env: AECEnv) -> ParallelEnv:
     In the case of an existing parallel environment wrapped using a `parallel_to_aec_wrapper`, this function will return the original parallel environment.
     Otherwise, it will apply the `aec_to_parallel_wrapper` to convert the environment.
     """
-    if isinstance(aec_env, OrderEnforcingWrapper) and isinstance(aec_env.env, parallel_to_aec_wrapper):
+    if isinstance(aec_env.env, parallel_to_aec_wrapper):
         return aec_env.env.env
     else:
         par_env = mo_aec_to_parallel_wrapper(aec_env)
@@ -40,8 +39,7 @@ def mo_parallel_to_aec(par_env: ParallelEnv) -> AECEnv:
         return par_env.aec_env
     else:
         aec_env = mo_parallel_to_aec_wrapper(par_env)
-        ordered_env = OrderEnforcingWrapper(aec_env)
-        return ordered_env
+        return aec_env
 
 
 class mo_aec_to_parallel_wrapper(aec_to_parallel_wrapper, MOParallelEnv):


### PR DESCRIPTION
`OrderEnforcing` prevents from accessing additional functions from the original PZ API, such as `reward_space`. This is not acceptable in our case.

The simplest way (this one) removes OrderEnforcing everywhere.
The harder way will need to reimplement an override of OrderEnforcing and expose an MOWrapper API... Which seems like a lot of code for very little value.