### PR TITLE
Bump libraries used in the project, remove python 3.9

### DIFF
--- a/.github/workflows/build-docs-dev.yml
+++ b/.github/workflows/build-docs-dev.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.9'
+            python-version: '3.12'
 
       - name: Install docs requirements
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/build-docs-version.yml
+++ b/.github/workflows/build-docs-version.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.9'
+            python-version: '3.12'
 
       - name: Install docs requirements
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Python](https://img.shields.io/pypi/pyversions/momaland.svg)](https://badge.fury.io/py/momaland)
 [![PyPI](https://badge.fury.io/py/momaland.svg)](https://badge.fury.io/py/momaland)
-![tests](https://github.com/rradules/momaland/workflows/Python%20tests/badge.svg)
+![tests](https://github.com/Farama-Foundation/momaland/workflows/Python%20tests/badge.svg)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,9 +40,9 @@ tutorials/learning_algorithms
 :caption: Development
 
 Discord <https://discord.gg/bnJ6kubTg6>
-Github <https://github.com/rradules/momaland>
+Github <https://github.com/Farama-Foundation/momaland>
 release_notes
-Contribute to the Docs <https://github.com/rradules/momaland/tree/master/docs/>
+Contribute to the Docs <https://github.com/Farama-Foundation/momaland/tree/master/docs/>
 ```
 
 ```{project-logo} _static/img/momaland-text.png

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 cython
 gymnasium
-git+https://github.com/rradules/momaland
+git+https://github.com/Farama-Foundation/MOMAland
 tqdm
 sphinx
 sphinx-autobuild

--- a/momaland/learning/cooperative_momappo/exec_policy.py
+++ b/momaland/learning/cooperative_momappo/exec_policy.py
@@ -53,7 +53,11 @@ def main():
     if args.continuous:
         from momaland.learning.cooperative_momappo.continuous_momappo import Actor
 
-        actor_module = Actor(single_action_space.shape[0], net_arch=args.actor_net_arch, activation=args.activation)
+        actor_module = Actor(
+            single_action_space.shape[0],
+            net_arch=args.actor_net_arch,
+            activation=args.activation,
+        )
         actor_state = TrainState.create(
             apply_fn=actor_module.apply,
             params=actor_module.init(actor_key, dummy_local_obs_and_id),
@@ -65,7 +69,11 @@ def main():
     else:
         from momaland.learning.cooperative_momappo.discrete_momappo import Actor
 
-        actor_module = Actor(single_action_space.shape[0], net_arch=args.actor_net_arch, activation=args.activation)
+        actor_module = Actor(
+            single_action_space.shape[0],
+            net_arch=args.actor_net_arch,
+            activation=args.activation,
+        )
         actor_state = TrainState.create(
             apply_fn=actor_module.apply,
             params=actor_module.init(actor_key, dummy_local_obs_and_id),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "momaland"
 description="A standard API for Multi-Objective Multi-Agent Decision making and a diverse set of reference environments."
 readme = "README.md"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 authors = [
     {name="Florian Felten", email="ffelten@mavt.ethz.ch"},
     {name="Roxana Radulescu", email="r.t.radulescu@uu.nl"},
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 4 - Beta",  # change to `5 - Production/Stable` when ready
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -83,7 +82,7 @@ momaland = [
 
 [tool.black]
 line-length = 127
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 
 [tool.isort]
@@ -101,7 +100,7 @@ exclude = ["**/node_modules", "**/__pycache__"]
 strict = []
 
 typeCheckingMode = "basic"
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 pythonPlatform = "All"
 typeshedPath = "typeshed"
 enableTypeIgnoreComments = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,8 @@ description="A standard API for Multi-Objective Multi-Agent Decision making and 
 readme = "README.md"
 requires-python = ">= 3.9"
 authors = [
-    {name="Florian Felten", email="florian.felten@uni.lu"},
-    {name="Umut Ucak"},
-    {name="Hicham Azmani"},
-    {name="Roxana Radulescu", email="roxana.radulescu@vub.be"},
-    {name="Hendrik J. S. Baier", email="h.j.s.baier@tue.nl"},
-    {name="Willem Röpke", email="willem.ropke@vub.be"},
-    {name="Patrick Mannion", email="patrick.mannion@universityofgalway.ie"},
-    {name="Diederik M. Roijers",email="diederik.roijers@vub.be"},
+    {name="Florian Felten", email="ffelten@mavt.ethz.ch"},
+    {name="Roxana Radulescu", email="r.t.radulescu@uu.nl"},
 ]
 license = { text = "GNU General Public License v3.0" }
 keywords = ["Reinforcement Learning", "Multi-Objective", "Multi-Agent", "RL", "AI", "gymnasium", "pettingzoo"]
@@ -36,7 +30,7 @@ dependencies = [
     "numpy >=1.21.0",
     "networkx >=3.1",
     "sympy >=1.12",
-    "pygame >=2.6.0",
+    "pygame >=2.3.0",
     "PyOpenGL >=3.1.6",
     "PyOpenGL-accelerate >=3.1.1",
     "pillow >=8.3.1",
@@ -47,38 +41,22 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
 learning = [
-    "jax >=0.4.13",
-    "chex >=0.1",
-    "distrax >= 0.1.3",
-    "flax >=0.6",
-    "optax >=0.1",
-    "orbax-checkpoint >=0.2.3",
-    "chex >=0.1",
-    "etils >=1.3",
-    "supersuit >=3.9",
-    "tqdm >=4.66.1",
+    "jax >=0.6.2",
+    "chex >=0.1.89",
+    "distrax >= 0.1.5",
+    "flax >=0.10.7",
+    "optax >=0.2.5",
+    "orbax-checkpoint >=0.11.19",
+    "etils >=1.13.0",
+    "supersuit >=3.10.0",
+    "tqdm >=4.67.1",
     "pandas >=2.0.3",
-    "matplotlib >=3.7.4",
-    "morl_baselines[all]",
+    "matplotlib >=3.10.0",
+    "morl_baselines[all] >=1.1.0",
     "pycddlib==2.1.6",
 ]
 all = [
-    # All dependencies above except accept-rom-license
-    # NOTE: No need to manually remove the duplicates, setuptools automatically does that
-    "jax >=0.4.13",
-    "chex >=0.1",
-    "distrax >=0.1.3",
-    "flax >=0.6",
-    "optax >=0.1",
-    "orbax-checkpoint >=0.2.3",
-    "chex >=0.1",
-    "etils >=1.3",
-    "supersuit >=3.9",
-    "tqdm >=4.66.1",
-    "pandas >=2.0.3",
-    "matplotlib >=3.7.4",
-    "morl_baselines[all]",
-    "pycddlib==2.1.6",
+    "momaland[learning]",
 ]
 testing = ["pytest ==7.1.3"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,10 @@ all = [
 testing = ["pytest ==7.1.3"]
 
 [project.urls]
-Homepage = "https://github.com/rradules/momaland/tree/main"
-Repository = "https://github.com/rradules/momaland/tree/main"
-Documentation = "https://github.com/rradules/momaland/tree/main"
-"Bug Report" = "https://github.com/rradules/momaland/tree/main/issues"
+Homepage = "https://momaland.farama.org/"
+Repository = "https://github.com/Farama-Foundation/momaland"
+Documentation = "https://momaland.farama.org/"
+"Bug Report" = "https://github.com/Farama-Foundation/momaland/tree/main/issues"
 
 [tool.setuptools]
 include-package-data = true

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ CWD = pathlib.Path(__file__).absolute().parent
 
 
 def get_version():
-    """Gets the mo-gymnasium version."""
+    """Gets the momaland version."""
     path = CWD / "momaland" / "__init__.py"
     content = path.read_text()
     for line in content.splitlines():


### PR DESCRIPTION
This one bumps all the libraries (esp. jax related stuffs) to later versions. I ran a quick check on momappo continuous and it seems to run with Python 3.12.

Jax has dropped Python 3.9 a while ago, since 3.9 will end of life in October, I am already preparing this PR to remove it.

I suggest merging this after the paper has been accepted/released.