### PR TITLE
Use lightweight pygame init in connect4, item_gathering, crazyrl

### DIFF
--- a/momaland/envs/connect4/connect4.py
+++ b/momaland/envs/connect4/connect4.py
@@ -306,9 +306,11 @@ class MOConnect4(MOAECEnv, EzPickle):
         screen_height = 86 / 99 * screen_width
 
         if self.screen is None:
-            pygame.init()
-
             if self.render_mode == "human":
+                # Only initialize the display subsystem on the human render path. pygame.init() also
+                # starts the unused audio mixer and joystick subsystems, whose device enumeration adds
+                # ~0.4s of startup (see Farama-Foundation/MOMAland#71).
+                pygame.display.init()
                 pygame.display.set_caption("Connect Four")
                 self.screen = pygame.display.set_mode((screen_width, screen_height))
             else:

--- a/momaland/envs/crazyrl/crazyRL_base.py
+++ b/momaland/envs/crazyrl/crazyRL_base.py
@@ -318,7 +318,9 @@ class CrazyRLBaseParallelEnv(MOParallelEnv):
 
         def init_window():
             """Initializes the PyGame window."""
-            pygame.init()
+            # pygame.init() also starts the unused audio mixer and joystick subsystems, whose device
+            # enumeration adds ~0.4s of startup (see Farama-Foundation/MOMAland#71); only the display
+            # subsystem (initialized below) is needed.
             pygame.display.init()
             pygame.display.set_caption("Crazy RL")
 

--- a/momaland/envs/item_gathering/item_gathering.py
+++ b/momaland/envs/item_gathering/item_gathering.py
@@ -256,7 +256,9 @@ class MOItemGathering(MOParallelEnv, EzPickle):
             warn("You are calling render method without specifying any render mode.")
             return
         if self.window is None:
-            pygame.init()
+            # pygame.init() also starts the unused audio mixer and joystick subsystems, whose device
+            # enumeration adds ~0.4s of startup (see Farama-Foundation/MOMAland#71). Only the display
+            # is needed, and it is initialized on the human render path below.
             get_colored("item", len(self.item_dict))
             get_colored("agent", len(self.agents))
 


### PR DESCRIPTION
pygame.init() also starts the audio mixer and joystick subsystems, whose device enumeration adds ~0.4s of startup even when those subsystems are unused (Farama-Foundation/MOMAland#71; same change as Gymnasium#1586 and PettingZoo#1343). None of these environments use audio, joystick, or font, so initialize only the display subsystem, and only on the human render path (rgb_array uses an offscreen Surface that needs no display).

Closes #71.