### PR TITLE
Update to Numpy 2.0 and Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/momaland/envs/gem_mining/gem_mining.py
+++ b/momaland/envs/gem_mining/gem_mining.py
@@ -169,7 +169,7 @@ class MOGemMining(MOParallelEnv, EzPickle):
 
         # determine the number of workers per village (agent):
         lst = list(range(min_workers, max_workers + 1))
-        self.workers = {agent: self.random.choices(lst) for agent in self.agents}
+        self.workers = {agent: self.random.choice(lst) for agent in self.agents}
 
         # determine the base probabilities of finding a gem per type per mine
         self.base_probabilities = dict()

--- a/momaland/envs/samegame/same_game.py
+++ b/momaland/envs/samegame/same_game.py
@@ -170,7 +170,7 @@ class MOSameGame(MOAECEnv, EzPickle):
         self.env = super().__init__()
 
         self.rng = np.random.default_rng()
-        self.rng_initial_state = self.rng.__getstate__()
+        self.rng_initial_state = self.rng.bit_generator.state
         self.gameinfo = {}
         self.gameinfo["ncolors"] = num_colors
         self.gameinfo["boardcols"] = board_width
@@ -348,7 +348,7 @@ class MOSameGame(MOAECEnv, EzPickle):
     @override
     def reset(self, seed=None, options=None):
         if seed is None:
-            self.rng.__setstate__(self.rng_initial_state)
+            self.rng.bit_generator.state = self.rng_initial_state
         else:
             self.rng = np.random.default_rng(seed)
         self.agents = self.possible_agents[:]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,14 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     'Intended Audience :: Science/Research',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ]
 dependencies = [
     "gymnasium >=1.1.0",
     "pettingzoo[sisl,butterfly] >=1.24.0",
-    "numpy >=1.21.0",
+    "numpy >=2.0.0",
     "networkx >=3.4",
     "sympy >=1.12",
     "pygame-ce >=2.3.0",
@@ -51,7 +52,7 @@ learning = [
     "tqdm >=4.67.1",
     "pandas >=2.0.3",
     "matplotlib >=3.10.0",
-    "morl_baselines[all] >=1.1.0",
+    "morl_baselines[all] >=1.3.0",
     "pycddlib==2.1.6",
 ]
 all = [
@@ -82,7 +83,7 @@ momaland = [
 
 [tool.black]
 line-length = 127
-target-version = ['py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312', 'py313']
 include = '\.pyi?$'
 
 [tool.isort]

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,9 +1,11 @@
 import os
 import pickle
 
+import numpy as np
 import pytest
 from pettingzoo.test import parallel_api_test, seed_test
 
+from momaland.envs.samegame import mosame_game_v0
 from momaland.test.api_test import api_test
 
 # from momaland.test.wrapper_test import wrapper_test
@@ -26,3 +28,15 @@ def test_module(name, env_module):
     recreated_env = pickle.loads(pickle.dumps(_env))
     # TODO recreated_env.seed(42)
     api_test(recreated_env)
+
+
+def test_samegame_reset_reproducible():
+    env = mosame_game_v0.env(render_mode=None)
+    env.reset()
+    first_board, *_ = env.last()
+    env.reset()
+    second_board, *_ = env.last()
+
+    assert np.array_equal(
+        first_board["observation"], second_board["observation"]
+    ), "no-seed reset() must reproduce the same board."


### PR DESCRIPTION
## What

Completes the numpy 2 and Python 3.13 upgrades for MOMAland.

### numpy 2.0

- `pyproject.toml`: `numpy >=1.21.0` -> `numpy >=2.0.0`.
- `gem_mining.py`: `MOGemMining` assigned `random.choices()` (a one-element list) into an `int32`
  array slot. numpy 1.25 deprecated that conversion and numpy 2.0 made it a hard error. Use
  `random.choice()` so the per-village worker count is a scalar. Correct on numpy 1.x and 2.0.

### Python 3.13

- `pyproject.toml`: add the `Programming Language :: Python :: 3.13` classifier and `py313` to
  `black`'s `target-version`.
- `.github/workflows/test.yml`: add `3.13` to the CI test matrix (`['3.10', '3.11', '3.12', '3.13']`).

### Unblock the learning stack

- `pyproject.toml`: `morl_baselines[all] >=1.1.0` -> `>=1.3.0`. morl_baselines 1.3.0 dropped its
  `numpy<2` cap, which is what previously made `.[all]` unresolvable under numpy 2.

