### PR TITLE
Bump pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ learning = [
 all = [
     "momaland[learning]",
 ]
-testing = ["pytest ==7.1.3"]
+testing = ["pytest == 9.0.3"]
 
 [project.urls]
 Homepage = "https://momaland.farama.org/"


### PR DESCRIPTION
Dependabot flagged a security vulnerability in the pinned version and couldn't create an automated PR like normal for whatever reason