### PR TITLE
Deploy main-branch docs under /main/ so the version selector loads

### DIFF
--- a/.github/workflows/build-docs-dev.yml
+++ b/.github/workflows/build-docs-dev.yml
@@ -43,4 +43,5 @@ jobs:
         with:
           folder: _build
           branch: gh-pages
+          target-folder: main
           clean: false


### PR DESCRIPTION
## Problem

momaland.farama.org has the version-selector script and **already has version folders deployed** to `gh-pages` (`v0.0.1`, `v0.0.2`, `v0.2.0`, `0.1.0`, `0.1.1`, …) from `build-docs-version.yml`. But the dropdown never loads, because the page fetches `/main/_static/versioning/versioning_menu.html` and there is **no `/main/` directory** — `build-docs-dev.yml` deploys the main build to the `gh-pages` **root** (`folder: _build`, `branch: gh-pages`, no `target-folder`).

So `/main/_static/versioning/versioning_menu.html` 404s even though the version docs exist.

## Change

Add `target-folder: main` to the dev workflow's deploy step so main docs publish under `/main/` (it already has `clean: false`, so sibling version folders survive). The release workflow (`build-docs-version.yml`) is already correct and unchanged.

Once `/main/` exists, the selector loads and — because the version folders are already deployed — it immediately offers `main` plus the existing releases. This also removes a latent conflict where both the dev workflow (every main push) and the release workflow's root step were writing the `gh-pages` root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)