### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   linux-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/MOMAland/security/code-scanning/3](https://github.com/Farama-Foundation/MOMAland/security/code-scanning/3)

To fix this, add an explicit `permissions` block to the workflow (or job) defining the least privileges needed.  
Best single fix here: add a **top-level** `permissions` block with `contents: read`, since all current jobs/steps only need to read repository content for checkout and testing.

**Where to change:**
- File: `.github/workflows/test.yml`
- Add the block after the `on:` trigger section (before `jobs:`), or alternatively under `linux-test:` if you want job-scoped permissions. Workflow-level is clean and sufficient here.

**What is needed:**
- No imports, methods, or dependencies.
- Only YAML edit: add
  ```yaml
  permissions:
    contents: read
  ```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
