### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,6 +14,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/MOMAland/security/code-scanning/2](https://github.com/Farama-Foundation/MOMAland/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so all jobs receive least-privilege token access by default.

Best fix here: in `.github/workflows/build-publish.yml`, add a workflow-level permissions section immediately after the `on:` triggers (before `jobs:`), setting:
- `contents: read` (needed for checkout and general repository read operations)

No additional write scopes are required by the shown steps (`upload-artifact`, `download-artifact`, and PyPI publish via secret) for this workflow snippet. This keeps behavior unchanged while removing implicit/default token privilege reliance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
